### PR TITLE
Update aurora to v2

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,9 +87,9 @@ Source Code and Artifacts:
 
 #### Stocks DB
 
-Aurora RDS DB (serverless v1) SQL database:
+Aurora RDS DB (serverless v2) SQL database:
 
-- MySQL 5.7
+- MySQL 8.0
 
 ### Prerequisites
 Ensure that the following tools are installed and configured appropriately.


### PR DESCRIPTION
`Aurora Serverless v1` [end-of-life date: March 31st, 2025](https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/aurora-serverless.html)

- `Aurora Serverless v2` requires at least one instance therefore, `"aws_rds_cluster_instance"` was added to the `/modules/aurora/main.tf`
